### PR TITLE
Added support for webpack 4.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,16 @@ const contentRepeat = require('./lib/contentRepeat');
 function HtmlWebpackPrefixPlugin() {}
 
 HtmlWebpackPrefixPlugin.prototype.apply = function (compiler) {
-  compiler.plugin('compilation', (compilation) => {
-    compilation.plugin('html-webpack-plugin-after-html-processing', (htmlPluginData, callback) => {
+  (compiler.hooks
+      ? compiler.hooks.compilation.tap.bind(compiler.hooks.compilation, 'html-webpack-plugin-after-html-processing')
+      : compiler.plugin.bind(compiler, 'compilation')
+  )((compilation) => {
+
+    (compilation.hooks
+        ? compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync.bind(compilation.hooks.htmlWebpackPluginAfterHtmlProcessing, 'html-webpack-plugin-after-html-processing')
+        : compilation.plugin.bind(compilation, 'html-webpack-plugin-after-html-processing')
+    )((htmlPluginData, callback) => {
+
       const newData = Object.assign(htmlPluginData, {
         html: this.addPrefix(htmlPluginData.html, htmlPluginData.plugin.options),
       });
@@ -14,7 +22,6 @@ HtmlWebpackPrefixPlugin.prototype.apply = function (compiler) {
   });
 };
 
-
 HtmlWebpackPrefixPlugin.prototype.addPrefix = function (html, options) {
   if (options.prefix) {
     const rawLinks = HTMLMatcher(html, options.attrs);
@@ -22,6 +29,5 @@ HtmlWebpackPrefixPlugin.prototype.addPrefix = function (html, options) {
   }
   return html;
 };
-
 
 module.exports = HtmlWebpackPrefixPlugin;


### PR DESCRIPTION
Issue:

In webpack 4, I ran into the following error:

```
ERROR in   TypeError: callback is not a function

  - index.js:15 compilation.plugin
    /Users/johnpucciarelli/repos/html-webpack-prefix-plugin/index.js:15:7
```
Fix:

To fix this, I added conditional checks for the `hooks` property. I followed `favicons-webpack-plugin` as an example.

See: https://github.com/jantimon/favicons-webpack-plugin/blob/master/index.js#L44-L47